### PR TITLE
re-use cidr type everywhere

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -71,18 +71,12 @@ params:
         - master_ipv4_cidr_block
       properties:
         cluster_ipv4_cidr_block:
-          type: string
-          pattern: ^(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3})?(?:\/(?:[0-9]|[1-2][0-9]|3[0-2]))?$
-          message:
-            pattern: Must be a valid CIDR block (10.100.0.0/16) or a netmask (/16)
+          $ref: https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/cidr.json
           title: Pods IPv4 CIDR Block
           default: "/16"
           description: "CIDR block to use for kubernetes pods. Set to /netmask (e.g. /16) to have a range chosen with a specific netmask. Set to a CIDR notation (e.g. 10.96.0.0/14) from the RFC-1918 private networks (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to use."
         services_ipv4_cidr_block:
-          type: string
-          pattern: ^(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3})?(?:\/(?:[0-9]|[1-2][0-9]|3[0-2]))?$
-          message:
-            pattern: Must be a valid CIDR block (10.100.0.0/20) or a netmask (/20)
+          $ref: https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/cidr.json
           title: Services IPv4 CIDR Block
           default: "/20"
           description: "CIDR block to use for kubernetes services. Set to /netmask (e.g. /20) to have a range chosen with a specific netmask. Set to a CIDR notation (e.g. 10.96.0.0/14) from the RFC-1918 private networks (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to use."


### PR DESCRIPTION
not sure if in consistent use of the cidr type from artifact definitions was intentional.