### PR TITLE
remove conversion field widget

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -82,10 +82,12 @@ params:
                         - retention_days
                       properties:
                         persistence_size:
-                          type: string
+                          type: integer
                           title: Persistence Size GiB
                           description: Size of the persistent volume to use for OpenSearch
-                          default: "10"
+                          minimum: 1
+                          maximum: 10000
+                          default: 10
                         retention_days:
                           type: integer
                           title: Retention Days
@@ -283,9 +285,3 @@ ui:
       items:
         ui:field: dnsZonesDropdown
         cloud: gcp
-  observability:
-    logging:
-      opensearch:
-        persistence_size:
-          ui:field: conversionFieldData
-          default: Gibabytes


### PR DESCRIPTION
unfortunately the conversionFieldWidget is still causing problems even when the field is made type string. 
This PR removes the conversionFieldWidget.