### PR TITLE
Adding 1.23 and 1.24 as gke k8s versions

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -102,10 +102,12 @@ params:
       title: Kubernetes Version
       description: The version of Kubernetes to run
       enum:
-        - "1.19"
-        - "1.20"
-        - "1.21"
+        - "1.24"
+        - "1.23"
         - "1.22"
+        - "1.21"
+        - "1.20"
+        - "1.19"
     cluster_configuration:
       type: object
       title: Cluster Configuration


### PR DESCRIPTION
I've been wondering if this should be an API call. If it's an API call (widget) and the param is type string then we can update this on the backend. 

The downside to an enum being, if a cluster is made with 1.19 and we remove that from the enum list... the next deploy will not be valid since 1.19 is no longer in the list.