### PR TITLE
allow option for spot instance node pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Form input parameters for configuring a bundle for deployment.
 - **`k8s_version`** *(string)*: The version of Kubernetes to run. Must be one of: `['1.23', '1.22', '1.21', '1.20', '1.19']`. Default: `1.22`.
 - **`node_groups`** *(array)*
   - **Items** *(object)*: Definition of a node group.
+    - **`is_spot`** *(boolean)*: Spot instances are more affordable, but can be preempted at any time. Default: `False`.
     - **`machine_type`** *(string)*: Machine type to use in the node group. Default: `e2-standard-2`.
       - **One of**
         - Shared-core: 2 vCPUs 2GB Memory

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -152,6 +152,7 @@ params:
           - machine_type
           - min_size
           - max_size
+          - is_spot
         properties:
           name:
             type: string
@@ -172,6 +173,11 @@ params:
             title: Maximum Size
             description: Maximum number of instances in the node group
             default: 10
+          is_spot:
+            type: boolean
+            title: Use Spot Instances
+            description: Spot instances are more affordable, but can be preempted at any time.
+            default: false
           machine_type:
             type: string
             title: Machine type
@@ -269,6 +275,7 @@ ui:
         - machine_type
         - min_size
         - max_size
+        - is_spot
         - "*"
   core_services:
     ui:order:

--- a/src/main.tf
+++ b/src/main.tf
@@ -148,6 +148,7 @@ resource "google_container_node_pool" "nodes" {
 
   node_config {
     machine_type = each.value.machine_type
+    spot         = each.value.is_spot
 
     # IMAGE TYPE
     # Pre-configured: Container-Optimized OS with containerd


### PR DESCRIPTION
Allows customers to have node pools that are on-demand and node pools that are spot. Defaults to on-demand nodes. 