### PR TITLE
update service account for 1.24 and remove opensearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Form input parameters for configuring a bundle for deployment.
 <!-- PARAMS:START -->
 ## Properties
 
+- **`cluster_configuration`** *(object)*: Configure the basic settings and capabilities of the cluster.
+  - **`enable_binary_authorization`** *(boolean)*: WARNING: This can prevent container workloads from running! Binary Authorization is a deploy-time security control that ensures only trusted container images are deployed on Google Kubernetes Engine (GKE). More information here: https://cloud.google.com/binary-authorization. Default: `False`.
 - **`cluster_networking`** *(object)*: Configure the network configuration of the cluster.
   - **`cluster_ipv4_cidr_block`** *(string)*: CIDR block to use for kubernetes pods. Set to /netmask (e.g. /16) to have a range chosen with a specific netmask. Set to a CIDR notation (e.g. 10.96.0.0/14) from the RFC-1918 private networks (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to use. Default: `/16`.
   - **`master_ipv4_cidr_block`** *(string)*: CIDR block to use for kubernetes control plane. The mask for this must be exactly /28. Must be from the RFC-1918 private networks (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), and should not conflict with other ranges in use. It is recommended to use consecutive /28 blocks from the 172.16.0.0/16 range for all your GKE clusters (172.16.0.0/28 for the first cluster, 172.16.0.16/28 for the second, etc.). Default: `172.16.0.0/28`.
@@ -74,11 +76,10 @@ Form input parameters for configuring a bundle for deployment.
   - **`cloud_dns_managed_zones`** *(array)*: Select any Cloud DNS Managed Zones associated with this cluster to allow the cluster to automatically manage DNS records and SSL certificates. Default: `[]`.
     - **Items** *(string)*
   - **`enable_ingress`** *(boolean)*: Enabling this will create an nginx ingress controller in the cluster, allowing internet traffic to flow into web accessible services within the cluster. Default: `False`.
-- **`k8s_version`** *(string)*: The version of Kubernetes to run. Must be one of: `['1.23', '1.22', '1.21', '1.20', '1.19']`. Default: `1.22`.
+- **`k8s_version`** *(string)*: The version of Kubernetes to run. Must be one of: `['1.19', '1.20', '1.21', '1.22']`.
 - **`node_groups`** *(array)*
   - **Items** *(object)*: Definition of a node group.
-    - **`is_spot`** *(boolean)*: Spot instances are more affordable, but can be preempted at any time. Default: `False`.
-    - **`machine_type`** *(string)*: Machine type to use in the node group. Default: `e2-standard-2`.
+    - **`machine_type`** *(string)*: Machine type to use in the node group.
       - **One of**
         - Shared-core: 2 vCPUs 2GB Memory
         - Shared-core: 2 vCPUs 4GB Memory
@@ -96,26 +97,20 @@ Form input parameters for configuring a bundle for deployment.
         - CPU: 8 vCPUs 8GB Memory
         - CPU: 16 vCPUs 16GB Memory
         - CPU: 32 vCPUs 32GB Memory
-        - GPU: 1 GPU 40GB Memory - NVIDIA A100 40GB
-        - GPU: 16 GPUs 640GB Memory - NVIDIA A100 40GB
-        - GPU: 1 GPU 80GB Memory - NVIDIA A100 80GB
     - **`max_size`** *(number)*: Maximum number of instances in the node group. Default: `10`.
     - **`min_size`** *(number)*: Minimum number of instances in the node group. Default: `1`.
     - **`name`** *(string)*: The name of the node group. Default: ``.
-- **`observability`** *(object)*: Configure logging and metrics collection and delivery for your entire cluster.
-  - **`logging`** *(object)*: Configure logging for your cluster.
-    - **`destination`** *(string)*: Where to send logs. Default: `disabled`.
-      - **One of**
-        - OpenSearch (in cluster)
-        - Disabled
 ## Examples
 
   ```json
   {
       "__name": "Development",
+      "k8s_version": "1.21",
       "node_groups": [
           {
-              "machine_type": "e2-standard-2",
+              "machine_type": [
+                  "e2-highcpu-2"
+              ],
               "max_size": 5,
               "min_size": 1,
               "name": "small-pool"
@@ -127,15 +122,20 @@ Form input parameters for configuring a bundle for deployment.
   ```json
   {
       "__name": "Production",
+      "k8s_version": "1.21",
       "node_groups": [
           {
-              "machine_type": "e2-standard-16",
+              "machine_type": [
+                  "e2-standard-16"
+              ],
               "max_size": 20,
               "min_size": 1,
               "name": "big-pool-general"
           },
           {
-              "machine_type": "e2-highmem-16",
+              "machine_type": [
+                  "e2-highmem-16"
+              ],
               "max_size": 6,
               "min_size": 1,
               "name": "big-pool-high-mem"
@@ -223,37 +223,18 @@ Connections from other bundles that this bundle depends on.
   - **`specs`** *(object)*
     - **`gcp`** *(object)*: .
       - **`project`** *(string)*
-      - **`region`** *(string)*: The GCP region to provision resources in.
+      - **`region`** *(string)*: GCP region. Must be one of: `['us-east1', 'us-east4', 'us-west1', 'us-west2', 'us-west3', 'us-west4', 'us-central1']`.
 
         Examples:
-        ```json
-        "us-east1"
-        ```
-
-        ```json
-        "us-east4"
-        ```
-
-        ```json
-        "us-west1"
-        ```
-
         ```json
         "us-west2"
         ```
 
-        ```json
-        "us-west3"
-        ```
+      - **`resource`** *(string)*
+      - **`service`** *(string)*
+      - **`zone`** *(string)*: GCP Zone.
 
-        ```json
-        "us-west4"
-        ```
-
-        ```json
-        "us-central1"
-        ```
-
+        Examples:
 - **`subnetwork`** *(object)*: A region-bound network for deploying GCP resources. Cannot contain additional properties.
   - **`data`** *(object)*
     - **`infrastructure`** *(object)*
@@ -322,67 +303,21 @@ Connections from other bundles that this bundle depends on.
         "projects/my-project/locations/us-west2/clusters/my-gke-cluster"
         ```
 
-      - **`vpc_access_connector`** *(string)*: GCP Resource Name (GRN).
-
-        Examples:
-        ```json
-        "projects/my-project/global/networks/my-global-network"
-        ```
-
-        ```json
-        "projects/my-project/regions/us-west2/subnetworks/my-subnetwork"
-        ```
-
-        ```json
-        "projects/my-project/topics/my-pubsub-topic"
-        ```
-
-        ```json
-        "projects/my-project/subscriptions/my-pubsub-subscription"
-        ```
-
-        ```json
-        "projects/my-project/locations/us-west2/instances/my-redis-instance"
-        ```
-
-        ```json
-        "projects/my-project/locations/us-west2/clusters/my-gke-cluster"
-        ```
-
   - **`specs`** *(object)*
     - **`gcp`** *(object)*: .
       - **`project`** *(string)*
-      - **`region`** *(string)*: The GCP region to provision resources in.
+      - **`region`** *(string)*: GCP region. Must be one of: `['us-east1', 'us-east4', 'us-west1', 'us-west2', 'us-west3', 'us-west4', 'us-central1']`.
 
         Examples:
-        ```json
-        "us-east1"
-        ```
-
-        ```json
-        "us-east4"
-        ```
-
-        ```json
-        "us-west1"
-        ```
-
         ```json
         "us-west2"
         ```
 
-        ```json
-        "us-west3"
-        ```
+      - **`resource`** *(string)*
+      - **`service`** *(string)*
+      - **`zone`** *(string)*: GCP Zone.
 
-        ```json
-        "us-west4"
-        ```
-
-        ```json
-        "us-central1"
-        ```
-
+        Examples:
 <!-- CONNECTIONS:END -->
 
 </details>

--- a/core-services/_artifacts.tf
+++ b/core-services/_artifacts.tf
@@ -10,7 +10,7 @@ locals {
       certificate-authority-data = data.google_container_cluster.cluster.master_auth.0.cluster_ca_certificate
     }
     user = {
-      token = lookup(data.kubernetes_secret.massdriver-cloud-provisioner_service-account_secret.data, "token")
+      token = lookup(kubernetes_secret_v1.massdriver-cloud-provisioner_token.data, "token")
     }
   }
 

--- a/core-services/observability.tf
+++ b/core-services/observability.tf
@@ -1,7 +1,9 @@
-locals {
-  enable_opensearch = var.observability.logging.destination == "opensearch"
-  enable_fluentbit  = local.enable_opensearch # we could add OR logic for other destinations that would require fluentbit
-  o11y_namespace    = "md-observability"
+
+resource "kubernetes_namespace_v1" "md-observability" {
+  metadata {
+    labels = var.md_metadata.default_tags
+    name   = "md-observability"
+  }
 }
 
 // Unless the user is running prometheus (or integrates an observability package like DD)
@@ -10,42 +12,5 @@ module "kube-state-metrics" {
   source      = "github.com/massdriver-cloud/terraform-modules//k8s-kube-state-metrics?ref=c336d59"
   md_metadata = var.md_metadata
   release     = "kube-state-metrics"
-  namespace   = local.o11y_namespace
-}
-
-module "opensearch" {
-  count              = local.enable_opensearch ? 1 : 0
-  source             = "github.com/massdriver-cloud/terraform-modules//k8s-opensearch?ref=5fc9525"
-  md_metadata        = var.md_metadata
-  release            = "opensearch"
-  namespace          = local.o11y_namespace
-  kubernetes_cluster = local.kubernetes_cluster_artifact
-  helm_additional_values = {
-    persistence = {
-      size = "${var.observability.logging.opensearch.persistence_size}Gi"
-    }
-  }
-  enable_dashboards = true
-  // this adds a retention policy to move indexes to warm after 1 day and delete them after a user configurable number of days
-  ism_policies = {
-    "hot-warm-delete" : templatefile("${path.module}/logging/opensearch/ism_hot_warm_delete.json.tftpl", { "log_retention_days" : var.observability.logging.opensearch.retention_days })
-  }
-}
-
-module "fluentbit" {
-  count = local.enable_fluentbit ? 1 : 0
-  # TODO replace ref with a SHA once k8s-fluentbit is merged
-  source             = "github.com/massdriver-cloud/terraform-modules//k8s-fluentbit?ref=f920d78"
-  md_metadata        = var.md_metadata
-  release            = "fluentbit"
-  namespace          = local.o11y_namespace
-  kubernetes_cluster = local.kubernetes_cluster_artifact
-  helm_additional_values = {
-    config = {
-      filters = file("${path.module}/logging/fluentbit/filter.conf")
-      outputs = templatefile("${path.module}/logging/fluentbit/opensearch_output.conf.tftpl", {
-        namespace = local.o11y_namespace
-      })
-    }
-  }
+  namespace   = kubernetes_namespace_v1.md-observability.metadata.0.name
 }

--- a/core-services/service_account.tf
+++ b/core-services/service_account.tf
@@ -1,11 +1,13 @@
-resource "kubernetes_service_account" "massdriver-cloud-provisioner" {
+resource "kubernetes_service_account_v1" "massdriver-cloud-provisioner" {
   metadata {
-    name   = "massdriver-cloud-provisioner"
-    labels = var.md_metadata.default_tags
+    name      = "massdriver-cloud-provisioner"
+    namespace = kubernetes_namespace_v1.md-core-services.metadata.0.name
+    labels    = var.md_metadata.default_tags
   }
+  automount_service_account_token = false
 }
 
-resource "kubernetes_cluster_role_binding" "massdriver-cloud-provisioner" {
+resource "kubernetes_cluster_role_binding_v1" "massdriver-cloud-provisioner" {
   metadata {
     name   = "massdriver-cloud-provisioner"
     labels = var.md_metadata.default_tags
@@ -17,14 +19,20 @@ resource "kubernetes_cluster_role_binding" "massdriver-cloud-provisioner" {
   }
   subject {
     kind      = "ServiceAccount"
-    name      = kubernetes_service_account.massdriver-cloud-provisioner.metadata.0.name
-    namespace = kubernetes_service_account.massdriver-cloud-provisioner.metadata.0.namespace
+    name      = kubernetes_service_account_v1.massdriver-cloud-provisioner.metadata.0.name
+    namespace = kubernetes_service_account_v1.massdriver-cloud-provisioner.metadata.0.namespace
   }
 }
 
-data "kubernetes_secret" "massdriver-cloud-provisioner_service-account_secret" {
+resource "kubernetes_secret_v1" "massdriver-cloud-provisioner_token" {
   metadata {
-    name   = kubernetes_service_account.massdriver-cloud-provisioner.default_secret_name
-    labels = var.md_metadata.default_tags
+    name      = "massdriver-cloud-provisioner-token"
+    namespace = kubernetes_namespace_v1.md-core-services.metadata.0.name
+    labels    = var.md_metadata.default_tags
+    annotations = {
+      "kubernetes.io/service-account.name" = kubernetes_service_account_v1.massdriver-cloud-provisioner.metadata.0.name
+    }
   }
+  type                           = "kubernetes.io/service-account-token"
+  wait_for_service_account_token = true
 }

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -36,64 +36,7 @@ params:
     - cluster_networking
     - node_groups
     - core_services
-    - observability
   properties:
-    observability:
-      type: object
-      title: Observability
-      description: Configure logging and metrics collection and delivery for your entire cluster
-      required:
-        -  logging
-      properties:
-        logging:
-          type: object
-          title: Logging
-          description: Configure logging for your cluster
-          required:
-            - destination
-          properties:
-            destination:
-              type: string
-              title: Destination
-              description: Where to send logs
-              default: "disabled"
-              oneOf:
-              - title: "OpenSearch (in cluster)"
-                const: "opensearch"
-              - title: "Disabled"
-                const: "disabled"
-          dependencies:
-            destination:
-              oneOf:
-                - properties:
-                    destination:
-                      const: "opensearch"
-                    opensearch:
-                      type: object
-                      title: OpenSearch
-                      required:
-                        - persistence_size
-                        - retention_days
-                      properties:
-                        persistence_size:
-                          type: integer
-                          title: Persistence Size GiB
-                          description: Size of the persistent volume to use for OpenSearch
-                          minimum: 1
-                          maximum: 10000
-                          default: 10
-                        retention_days:
-                          type: integer
-                          title: Retention Days
-                          description: Number of days to retain logs and metrics in an OpenSearch Index
-                          minimum: 1
-                          maximum: 365
-                          default: 7
-                  required:
-                    - opensearch
-                - properties:
-                    destination:
-                      const: "disabled"
     k8s_version:
       type: string
       title: Kubernetes Version
@@ -266,7 +209,6 @@ ui:
       - cluster_networking
       - node_groups
       - core_services
-      - observability
       - "*"
   node_groups:
     items:

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -27,10 +27,6 @@ params:
           machine_type: e2-standard-16
           min_size: 1
           max_size: 20
-        - name: big-pool-high-mem
-          machine_type: e2-highmem-16
-          min_size: 1
-          max_size: 6
   required:
     - k8s_version
     - cluster_networking


### PR DESCRIPTION
Changes for 1.24 Service Account Token

Also removed OpenSearch logging. This has been removed in EKS, AKS and GKE Autopilot. OpenSearch and FluentBit are both unstable. FluentBit restarts regularly and drops logs. OpenSearch consistently has Internal Server issues.  We'll solve logging another way.