### PR TITLE
Added g2-standard-4 & g2-standard-24 to support L4 GPUs

### DIFF
--- a/core-services/gpu_nvidia.tf
+++ b/core-services/gpu_nvidia.tf
@@ -1,7 +1,7 @@
 locals {
   machine_types = join("", var.node_groups[*].machine_type)
   # https://cloud.google.com/compute/docs/gpus#a100-gpus
-  install_nvidia_driver = length(regexall("-highgpu-|-megagpu-|-ultragpu-", local.machine_types)) > 0
+  install_nvidia_driver = length(regexall("-highgpu-|-megagpu-|-ultragpu-|g2-standard", local.machine_types)) > 0
 }
 
 # These drivers are required for the above machine types.

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -164,9 +164,9 @@ params:
                 const: a2-megagpu-16g
               - title: 'GPU: 1 GPU 80GB Memory - NVIDIA A100 80GB'
                 const: a2-ultragpu-1g
-              - title: 'GPU: 1 GPU 24GB Memory - NVIDIA L40'
+              - title: 'GPU: 1 GPU 24GB Memory - NVIDIA L4'
                 const: g2-standard-4
-              - title: 'GPU: 2 GPU 48GB Memory - NVIDIA L40'
+              - title: 'GPU: 2 GPU 48GB Memory - NVIDIA L4'
                 const: g2-standard-24
     core_services:
       type: object

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -164,6 +164,10 @@ params:
                 const: a2-megagpu-16g
               - title: 'GPU: 1 GPU 80GB Memory - NVIDIA A100 80GB'
                 const: a2-ultragpu-1g
+              - title: 'GPU: 1 GPU 24GB Memory - NVIDIA L40'
+                const: g2-standard-4
+              - title: 'GPU: 2 GPU 48GB Memory - NVIDIA L40'
+                const: g2-standard-24
     core_services:
       type: object
       title: Core Services


### PR DESCRIPTION
Adding support for G2 accelerated machines. Much better suited for inferencing clusters.

Ticket here: https://roadmap.massdriver.cloud/bundles/l40-gpus-for-gke-cllqyp37j0030n629rkbc8unq

Ref: https://cloud.google.com/compute/docs/gpus#l4-gpus